### PR TITLE
Add receivableBlocks.Blocks null check to RpcClient.AccountsPendingAsync

### DIFF
--- a/Nano.Net.Tests/RpcTest.cs
+++ b/Nano.Net.Tests/RpcTest.cs
@@ -68,7 +68,7 @@ public class RpcTest
     }
 
     [Fact]
-    public async void AccountsPending_ValidateResult_ValidResult2()
+    public async void AccountsPending_EmptyResult_BlocksNotNull()
     {
         string account = new Account().Address;
         AccountsPendingResponse accountsPendingResponse = await _rpcClient.AccountsPendingAsync(new string[] { account });

--- a/Nano.Net.Tests/RpcTest.cs
+++ b/Nano.Net.Tests/RpcTest.cs
@@ -68,6 +68,16 @@ public class RpcTest
     }
 
     [Fact]
+    public async void AccountsPending_ValidateResult_ValidResult2()
+    {
+        string account = new Account().Address;
+        AccountsPendingResponse accountsPendingResponse = await _rpcClient.AccountsPendingAsync(new string[] { account });
+        
+        Assert.NotNull(accountsPendingResponse.Blocks);
+        Assert.Empty(accountsPendingResponse.Blocks);
+    }
+
+    [Fact]
     public async void BlockInfo_ValidateResult_ValidResult()
     {
         BlockInfoResponse blockInfoResponse = await _rpcClient.BlockInfoAsync("75F0B821DE3B25908755520117660E1297DDEA774DEC817FAA2C27221442403A");

--- a/Nano.Net/RpcClient.cs
+++ b/Nano.Net/RpcClient.cs
@@ -211,11 +211,8 @@ namespace Nano.Net
                 Count = count
             });
 
-            // receiveableBlocks.Blocks is null when the accounts requested to check have no blocks
-            if (receivableBlocks.Blocks == null)
-            {
-                receivableBlocks.Blocks = new Dictionary<string, Dictionary<string, ReceivableBlock>>();
-            }
+            // AccountsPendingResponse.Blocks is null if the requested accounts have no receivable blocks
+            receivableBlocks.Blocks ??= new Dictionary<string, Dictionary<string, ReceivableBlock>>();
 
             foreach (var address in receivableBlocks.Blocks)
             {

--- a/Nano.Net/RpcClient.cs
+++ b/Nano.Net/RpcClient.cs
@@ -2,6 +2,7 @@
 
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -202,7 +203,7 @@ namespace Nano.Net
         /// </summary>
         public async Task<AccountsPendingResponse> AccountsPendingAsync(string[] accounts, int count = 5)
         {
-            var receivableBlocks =  await RpcRequestAsync<AccountsPendingResponse>(new
+            var receivableBlocks = await RpcRequestAsync<AccountsPendingResponse>(new
             {
                 Action = "accounts_pending",
                 Accounts = accounts,
@@ -210,11 +211,17 @@ namespace Nano.Net
                 Count = count
             });
 
+            // receiveableBlocks.Blocks is null when the accounts requested to check have no blocks
+            if (receivableBlocks.Blocks == null)
+            {
+                receivableBlocks.Blocks = new Dictionary<string, Dictionary<string, ReceivableBlock>>();
+            }
+
             foreach (var address in receivableBlocks.Blocks)
             {
                 if (address.Value is null)
                     continue;
-                
+
                 foreach (var block in address.Value)
                     block.Value.Hash = block.Key;
             }


### PR DESCRIPTION
Hi,
`RpcClient.AccountsPendingAsync` is throwing null reference exception when checking pending blocks of the account that doesn't have any of them. That's because response can't serialize Blocks to empty dictionary.  

![image](https://user-images.githubusercontent.com/35507241/166888549-79365208-c0ba-4b89-8eb1-0689c3fc05bc.png)

I fixed it in this commit, now it makes sure to return empty dictionary if the `Blocks` in response is null